### PR TITLE
Initialization order based on sum of cross correlations

### DIFF
--- a/bmd.R
+++ b/bmd.R
@@ -137,7 +137,7 @@ bmd <- function (X, Y, alpha = 0.05, OL_thres = 0.9, tag = NULL, saveDir = getwd
   
   Xindx <- 1:dx
   Yindx <- (dx + 1):(dx + dy)
-  
+
   # Defining pval function
   pvalFun <- function (B) {
     
@@ -729,10 +729,13 @@ bmd <- function (X, Y, alpha = 0.05, OL_thres = 0.9, tag = NULL, saveDir = getwd
   cat("Beginning method.\n\n")
   
   # Getting node orders
-  Yvar <- apply(Y, 2, var)
-  remainingY <- Yindx[order(Yvar, decreasing = TRUE)]
-  Xvar <- apply(X, 2, var)
-  remainingX <- Xindx[order(Xvar, decreasing = TRUE)]
+  Ysum <- Y_scaled %*% rep(1,dy)
+  Xsum <- X_scaled %*% rep(1,dx)
+  cor_X_to_Ysums <- as.vector(t(Ysum) %*% X_scaled)
+  cor_Y_to_Xsums <- as.vector(t(Xsum) %*% Y_scaled)
+  
+  remainingY <- Yindx[order(cor_Y_to_Xsums, decreasing = TRUE)]
+  remainingX <- Xindx[order(cor_X_to_Ysums, decreasing = TRUE)]
 
   # Initializing control variables
   didX <- TRUE

--- a/run_sims.R
+++ b/run_sims.R
@@ -1,0 +1,20 @@
+source("sims_config.R")
+
+RUN <- list(sims    =FALSE,
+            methods =FALSE,
+            plots   =TRUE)
+
+if(RUN$sims){
+  unlink(file.path(saveDir,"datasets"), recursive = TRUE)
+  source("sims.R")
+}
+
+if(RUN$methods){
+  unlink(file.path(saveDir,"results"), recursive = TRUE)
+  source("sims_run_methods.R")
+}
+
+if(RUN$plots){
+  unlink(file.path(saveDir,"plots"), recursive = TRUE)
+  source("simplots.R")
+}

--- a/run_sims.sh
+++ b/run_sims.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-Rscript sims.R
-Rscript sims_run_methods.R
-Rscript simplots.R


### PR DESCRIPTION
The order of initialization among the X set is now in the decreasing order of the sum of its correlations to the entire Y set. Similarly for the Y set. 
This seems to be working. In my runs, all the dud extractions have moved to the end. However the BMD's extracted have size 1000ish. So that's perhaps why the scores are not that good.



Also, run_sims.sh is converted to an Rscript which deletes directories before running. 