### PR TITLE
Additional arguments to bmd

### DIFF
--- a/bmd.R
+++ b/bmd.R
@@ -2,7 +2,10 @@ source("makeVars.R")
 source("stdize.R")
 bmd <- function (X, Y, alpha = 0.05, OL_thres = 0.9, tag = NULL, saveDir = getwd(),
                  updateOutput = TRUE, throwInitial = TRUE, OL_tol = Inf, Dud_tol = Inf, time_limit = 18000,
-                 updateMethod = 2, initializeMethod = 2, inv.length = TRUE, add_rate = 1, return_zs = TRUE) {
+                 updateMethod = 2, initializeMethod = 2, inv.length = TRUE, add_rate = 1, return_zs = TRUE,
+                 bmd_index=NULL) {
+  # bmd_index : A function that maps each vertex to the index of the bimodule
+  #           it contains.
 
   if (FALSE) {
     alpha = 0.05
@@ -821,6 +824,12 @@ bmd <- function (X, Y, alpha = 0.05, OL_thres = 0.9, tag = NULL, saveDir = getwd
     chain <- list(B_old)
     consec_jaccards <- NULL
     consec_sizes <- list(c(length(B_oldx), length(B_oldy)))
+    if(is.function(bmd_index)){
+      consec_composition <- list(table(sapply(B_old,bmd_index)))
+    } else {
+      consec_composition <- NULL
+    }
+
     found_cycle <- found_break <- NULL
     mean_jaccards <- NULL ## add all these to update_info
     itCount <- 0
@@ -857,7 +866,10 @@ bmd <- function (X, Y, alpha = 0.05, OL_thres = 0.9, tag = NULL, saveDir = getwd
       consec_jaccards <- c(consec_jaccards, consec_jaccard)
       mean_jaccards <- c(mean_jaccards, mean(jaccards))
       consec_sizes <- c(consec_sizes, list(c(length(B_newx), length(B_newy))))
-      
+      if(is.function(bmd_index)){
+        consec_composition <- c(consec_composition,
+                                list(table(sapply(B_new, bmd_index))))
+      }
       if (updateOutput) {
         cat(paste0("Update ", itCount, 
                    " is size ", length(B_new), 
@@ -933,6 +945,7 @@ bmd <- function (X, Y, alpha = 0.05, OL_thres = 0.9, tag = NULL, saveDir = getwd
     update_info[[comm_indx]] <- list("mean_jaccards" = mean_jaccards,
                                      "consec_jaccards" = consec_jaccards,
                                      "consec_sizes"= consec_sizes,
+                                     "consec_composition"=consec_composition,
                                      "found_cycle" = found_cycle,
                                      "found_break" = found_break)
     remainingX <- setdiff(remainingX, B_new)

--- a/bmd.R
+++ b/bmd.R
@@ -723,7 +723,6 @@ bmd <- function (X, Y, alpha = 0.05, OL_thres = 0.9, tag = NULL, saveDir = getwd
   }
   
   #-------------------------------------------------------------------------------
-  
   # Extractions set-up
 
   cat("Beginning method.\n\n")
@@ -821,7 +820,7 @@ bmd <- function (X, Y, alpha = 0.05, OL_thres = 0.9, tag = NULL, saveDir = getwd
     B_new <- c(Xindx, Yindx)
     chain <- list(B_old)
     consec_jaccards <- NULL
-    consec_sizes <- list()
+    consec_sizes <- list(c(length(B_oldx), length(B_oldy)))
     found_cycle <- found_break <- NULL
     mean_jaccards <- NULL ## add all these to update_info
     itCount <- 0

--- a/bmd.R
+++ b/bmd.R
@@ -3,7 +3,7 @@ source("stdize.R")
 bmd <- function (X, Y, alpha = 0.05, OL_thres = 0.9, tag = NULL, saveDir = getwd(),
                  updateOutput = TRUE, throwInitial = TRUE, OL_tol = Inf, Dud_tol = Inf, time_limit = 18000,
                  updateMethod = 2, initializeMethod = 2, inv.length = TRUE, add_rate = 1, return_zs = TRUE,
-                 bmd_index=NULL) {
+                 bmd_index=NULL, calc_full_cor=FALSE) {
   # bmd_index : A function that maps each vertex to the index of the bimodule
   #           it contains.
 
@@ -129,6 +129,10 @@ bmd <- function (X, Y, alpha = 0.05, OL_thres = 0.9, tag = NULL, saveDir = getwd
     }
   }
 
+  if(calc_full_cor){
+    cat("Calculating the full cross correlation matrix.\n")
+    full_xy_cor = cor(X,Y)
+  }
 
   # Setup calculations    
 
@@ -140,6 +144,15 @@ bmd <- function (X, Y, alpha = 0.05, OL_thres = 0.9, tag = NULL, saveDir = getwd
   
   Xindx <- 1:dx
   Yindx <- (dx + 1):(dx + dy)
+
+  cross_cor <- function(X_indx=1:dx, Y_indx=1:dy){
+    if (exists("full_xy_cor")){
+      return(full_xy_cor[X_indx, Y_indx])
+    } else {
+      return(cor(as.matrix(X[,X_indx]), as.matrix(Y[,Y_indx])))
+    }
+
+  }
 
   # Defining pval function
   pvalFun <- function (B) {
@@ -315,7 +328,7 @@ bmd <- function (X, Y, alpha = 0.05, OL_thres = 0.9, tag = NULL, saveDir = getwd
       fixdMat <- as.matrix(Y[ , fixdIndx])
       
       # Getting test stats and indices
-      all_stats <- n^(1 / 2) * colSums(cor(fixdMat, X))
+      all_stats <- n^(1 / 2) * rowSums(cross_cor(Y_indx=fixdIndx))
       nTest <- dx
       testOrder <- order(all_stats, decreasing = TRUE)
       
@@ -327,7 +340,7 @@ bmd <- function (X, Y, alpha = 0.05, OL_thres = 0.9, tag = NULL, saveDir = getwd
       fixdMat <- as.matrix(X[ , fixdIndx])
       
       # Getting test stats and indices
-      all_stats <- n^(1 / 2) * colSums(cor(fixdMat, Y))
+      all_stats <- n^(1 / 2) * colSums(cross_cor(X_indx=fixdIndx))
       nTest <- dy
       testOrder <- order(all_stats, decreasing = TRUE)
       
@@ -364,13 +377,13 @@ bmd <- function (X, Y, alpha = 0.05, OL_thres = 0.9, tag = NULL, saveDir = getwd
         if (K0 > 0) {
           R_k_A0 <- rowSums(cor(X[ , A1], X[ , A0]))
         }
-        Rhat_k_B <- rowSums(cor(X[ , A1], Y[ , fixdIndx]))
+        Rhat_k_B <- rowSums(cross_cor(A1, fixdIndx))
         RA1 <- cor(X[ , A1])
       } else {
         if (K0 > 0) {
           R_k_A0 <- rowSums(cor(Y[ , A1], Y[ , A0]))
         }
-        Rhat_k_B <- rowSums(cor(Y[ , A1], X[ , fixdIndx]))
+        Rhat_k_B <- colSums(cross_cor(fixdIndx, A1))
         RA1 <- cor(Y[ , A1])
       }
       
@@ -539,7 +552,7 @@ bmd <- function (X, Y, alpha = 0.05, OL_thres = 0.9, tag = NULL, saveDir = getwd
       # Calculating the variances
       {
         # General calcs
-        xyCors <- cor(X_scaled, fixdMat)
+        xyCors <- cross_cor(Y_indx = fixdIndx)
         y4 <- colSums(X_scaled^4)
         xRowSum <- rowSums(fixdMat)
         xRowSum2 <- tcrossprod(xyCors, fixdMat^2)
@@ -573,7 +586,7 @@ bmd <- function (X, Y, alpha = 0.05, OL_thres = 0.9, tag = NULL, saveDir = getwd
       # Calculating the variances
       {
         # General calcs
-        xyCors <- cor(Y_scaled, fixdMat)
+        xyCors <- t(cross_cor(X_indx=fixdIndx))
         y4 <- colSums(Y_scaled^4)
         xRowSum <- rowSums(fixdMat)
         xRowSum2 <- tcrossprod(xyCors, fixdMat^2)
@@ -640,7 +653,7 @@ bmd <- function (X, Y, alpha = 0.05, OL_thres = 0.9, tag = NULL, saveDir = getwd
       fixdIndx <- match(B, Yindx)
       fixdMat <- as.matrix(Y[ , fixdIndx])
       Uis <- X
-      cormeans <- as.vector(rowMeans(cor(X, fixdMat)))
+      cormeans <- as.vector(rowMeans(cross_cor(Y_indx = fixdIndx)))
       
     } else {
       
@@ -648,7 +661,7 @@ bmd <- function (X, Y, alpha = 0.05, OL_thres = 0.9, tag = NULL, saveDir = getwd
       fixdIndx <- match(B, Xindx)
       fixdMat <- as.matrix(X[ , fixdIndx])
       Uis <- Y
-      cormeans <- as.vector(rowMeans(cor(Y, fixdMat)))
+      cormeans <- as.vector(colMeans(cross_cor(X_indx=fixdIndx)))
       
     }
     
@@ -677,13 +690,13 @@ bmd <- function (X, Y, alpha = 0.05, OL_thres = 0.9, tag = NULL, saveDir = getwd
   
   initialize3 <- function(u){
     if (u <= dx) {
-      cor_to_u <- cor(X_scaled[,u], Y_scaled)
+      cor_to_u <- cross_cor(X_indx=u)
       fischer_tranformed_cor <- atanh(cor_to_u)*sqrt(n-3)
       pvals <- pnorm(fischer_tranformed_cor, lower.tail = FALSE)
       successes <- Yindx[bhy(pvals, alpha)]
     } else {
       if (u > dx) {
-        cor_to_u <- cor(Y_scaled[,u-dx], X_scaled)
+        cor_to_u <- cross_cor(Y_indx=u-dx)
         fischer_tranformed_cor <- atanh(cor_to_u)*sqrt(n-3)
         pvals <- pnorm(fischer_tranformed_cor, lower.tail = FALSE)
         successes <- Xindx[bhy(pvals, alpha)]

--- a/run_sims.R
+++ b/run_sims.R
@@ -1,8 +1,5 @@
+#!/usr/bin/env Rscript
 source("sims_config.R")
-
-RUN <- list(sims    =FALSE,
-            methods =FALSE,
-            plots   =TRUE)
 
 if(RUN$sims){
   unlink(file.path(saveDir,"datasets"), recursive = TRUE)
@@ -15,6 +12,7 @@ if(RUN$methods){
 }
 
 if(RUN$plots){
-  unlink(file.path(saveDir,"plots"), recursive = TRUE)
+  unlink(file.path(saveDir,"plots","bmd"), recursive = TRUE)
+  unlink(file.path(saveDir,"plots","bmd-kb"), recursive = TRUE)
   source("simplots.R")
 }

--- a/sim_postanalysis.R
+++ b/sim_postanalysis.R
@@ -19,6 +19,9 @@ sim_postanalysis <- function (results, X, Y, run_name, run_dir,
     dir.create(run_dir)
   }
 
+  cat("calculating full cross-correlation matrix...\n")
+  full_cross_cor <- cor(X,Y)
+
   cat("calculating basic stats...\n")
 
   # Calculating basic stats
@@ -106,7 +109,7 @@ sim_postanalysis <- function (results, X, Y, run_name, run_dir,
     comm_df <- data.frame("X_indx" = rep(X_mch, each = nY),
                           "Y_indx" = rep(Y_mch, nX))
 
-    corrs <- cor(X_scl[ , X_mch], Y_scl[ , Y_mch])
+    corrs <- full_cross_cor[X_mch, Y_mch]
     comm_df$corrs <- as.vector(t(corrs))
 
     if (GTEx) {
@@ -230,7 +233,7 @@ sim_postanalysis <- function (results, X, Y, run_name, run_dir,
   cat("computing within-community correlations...\n")
   comm_corrs <- unlist(lapply(comm_dfs, function (df) df$corrs))
   cat("computing all correlations...\n")
-  all_corrs <- as.vector(cor(X, Y))
+  all_corrs <- as.vector(full_cross_cor)
 
   cat("formatting for correlation density plot...\n")
   corrs0 <- density(all_corrs)
@@ -338,7 +341,7 @@ sim_postanalysis <- function (results, X, Y, run_name, run_dir,
   #-------------------------------------------------------------
   # COMPUTE: CORMAT
   #-------------------------------------------------------------
-  crossCors <- cor(X, Y)
+  crossCors <- full_cross_cor
   Yindxs <- nrow(crossCors) + 1:ncol(crossCors)
   X_sets <- results$communities$X_sets[commsizes_ord]
   Y_sets <- lapply(results$communities$Y_sets, function (C) match(C, Yindxs))[commsizes_ord]

--- a/sim_postanalysis.R
+++ b/sim_postanalysis.R
@@ -83,8 +83,8 @@ sim_postanalysis <- function (results, X, Y, run_name, run_dir,
       y <- total_sizes <- sapply(consec_size_pairs, sum) #total module size
       plot(0, 0, xlim = c(0, uilength + 1), ylim = range(y) + c(-1,1), col = "white",
             main = "module sizes", xlab = "update no.", ylab = "Module size")
-      lines(1:uilength, y)
-      points(1:uilength, y,
+      lines(0:uilength, y)
+      points(0:uilength, y,
              col = as.numeric(updateInfoi[[1]]$found_cycle) + 1,
              pch = as.numeric(updateInfoi[[1]]$found_break) + 16)
       dev.off()

--- a/sims.R
+++ b/sims.R
@@ -1,7 +1,6 @@
 library(MASS)
 library(Matrix)
 library(lpbrim)
-library(igraph)
 source("sims_config.R")
 source("mvrnormR.R")
 source("ggcor.R")
@@ -71,8 +70,8 @@ for (n in ns) {
     crossindx2 <- (dim(G)[2] + 1):dimGiAdj
     GiAdj[crossindx1, crossindx2] <- G[i, , ]
     GiAdj[crossindx2, crossindx1] <- t(G[i, , ])
-    Gi <- graph.adjacency(GiAdj, mode = "undirected")
-    componentsi <- components(Gi)
+    Gi <- igraph::graph.adjacency(GiAdj, mode = "undirected")
+    componentsi <- igraph::components(Gi)
     nci <- max(componentsi$membership)
     cci <- lapply(1:nci, function (c) which(componentsi$membership == c))
     
@@ -97,10 +96,12 @@ for (n in ns) {
 
   # Plotting correlation matrices
   combineData <- cbind(X, Y)
-  combineCors <- cor(combineData)
   dX <- ncol(X); dY <- ncol(Y)
   
   if (plot_full_mat) {
+    cat("--calculating combined cor")
+    combineCors <- cor(combineData)
+
     cat("--plotting full matrix...\n")
     # Order by connected components
     Xindx <- unlist(lapply(component_list, function (cc) cc[cc <= dX]))

--- a/sims_config.R
+++ b/sims_config.R
@@ -8,6 +8,10 @@ simname <- "manyblocks-sparse"
 ns <- c(100, 500, seq(1000, 5000, by = 1000)) #The sample sizes to run.
 doBRIM <- FALSE #Should we test BRIM?
 
+RUN <- list(sims    =TRUE,
+            methods =TRUE,
+            plots   =TRUE)
+
 plot_full_mat <- FALSE
 
 saveDir <- file.path("sims", simname)

--- a/sims_config.R
+++ b/sims_config.R
@@ -3,7 +3,8 @@
 # Otherwise there should be a file called -
 #       paste0("config-files/sims_config-",simname,".R")
 
-simname <- "manyblocks-sparse"
+SIMNAMES <- c("oneblock-varAdj","manyblocks-sparse","manyblocks-sparse-varAdj")
+simname <- SIMNAMES[3]
 
 ns <- c(100, 500, seq(1000, 5000, by = 1000)) #The sample sizes to run.
 doBRIM <- FALSE #Should we test BRIM?

--- a/sims_debug_tools.R
+++ b/sims_debug_tools.R
@@ -1,0 +1,27 @@
+source("sims_config.R")
+
+#Size of all the X (or Y) variables
+total_variables <- (nBg + nBM*nB)*sB
+signal_nodes <- nBM*nB*sB
+
+is_X <- function(u){
+  u <= total_variables
+}
+
+bmd_index <- function(u){
+  #Return the index of the bimodule u belongs to
+  #Otherwise 0 if it's a noise node.
+
+  if (u > total_variables){
+    #So it must be a Y variable
+    u <- u - total_variables
+  }
+
+  if( u <= signal_nodes ){
+    #It is signal node. Return the index of the bimodule.
+    return(1 + (u-1) %/% (nB*sB))
+  }
+
+  #Otherwise it must be noise.
+  return(0)
+}

--- a/sims_run_methods.R
+++ b/sims_run_methods.R
@@ -52,7 +52,7 @@ for (n in ns) {
                     saveDir = file.path(saveDir, "BMD_saves"),
                     updateMethod = 5, initializeMethod = 3,
                     Dud_tol = 10, OL_tol = 10, time_limit = 1800,
-                    bmd_index = bmd_index)
+                    bmd_index = bmd_index, calc_full_cor=TRUE)
   )
 
   BMDtime <- proc.time()[3] - BMDtime
@@ -64,7 +64,8 @@ for (n in ns) {
   BMDresults <- bmd(X, Y, tag = n,
                     saveDir = file.path(saveDir, "BMD_saves"),
                     updateMethod = 6, initializeMethod = 3,
-                    Dud_tol = 10, OL_tol = 10, time_limit = 1800)
+                    Dud_tol = 10, OL_tol = 10, time_limit = 1800,
+                    bmd_index = bmd_index, calc_full_cor=TRUE)
   )
   BMDtime <- proc.time()[3] - BMDtime
   save(BMDtime, BMDresults,

--- a/sims_run_methods.R
+++ b/sims_run_methods.R
@@ -4,6 +4,7 @@ library(lpbrim)
 source("bmd.R")
 source("formatBRIM.R")
 source("sims_config.R")
+source("sims_debug_tools.R")
 
 for (n in ns) {
 
@@ -50,8 +51,10 @@ for (n in ns) {
   BMDresults <- bmd(X, Y, tag = n,
                     saveDir = file.path(saveDir, "BMD_saves"),
                     updateMethod = 5, initializeMethod = 3,
-                    Dud_tol = 10, OL_tol = 10, time_limit = 1800)
+                    Dud_tol = 10, OL_tol = 10, time_limit = 1800,
+                    bmd_index = bmd_index)
   )
+
   BMDtime <- proc.time()[3] - BMDtime
   save(BMDtime, BMDresults,
        file = results_fname(n, method="bmd"))


### PR DESCRIPTION
* ``bmd_index`` 
This is a  function that maps every node to the index of the true Bimodule it lies in. Currently ``bmd()``  uses this to return the composition (the counts per bimodule) of each update in ``update_info[[comm_indx]]$consec_composition``.

* ``calc_full_cor``
If  ``TRUE`` then ``bmd()`` calculates the full cross-correlation matrix at the outset. Doing this has caused a 3x speedup in my runs. Perhaps in the future we could implement a lazy version of the ``cross_cor`` function in RCPP. Then we might continue to have the speed advantage without having to compute the full cross-correlation  matrix.